### PR TITLE
chore(pingpong-gitops-config/pong/overlays/dev): bump daoquocquyen/pong to 1.0.0-72699db

### DIFF
--- a/pong/overlays/dev/kustomization.yaml
+++ b/pong/overlays/dev/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
   - configmap.yaml
 images:
   - name: daoquocquyen/pong
-    newTag: 1.0.0-144b74b
+    newTag: 1.0.0-72699db
 patches:
   - path: deployment-patch.yaml


### PR DESCRIPTION
Update `kustomization.yaml` to set `newTag: 1.0.0-72699db` for `daoquocquyen/pong`.