### PR TITLE
chore(pingpong-gitops-config/pong/overlays/dev): bump daoquocquyen/pong to 1.0.0-dc475a2

### DIFF
--- a/pong/overlays/dev/kustomization.yaml
+++ b/pong/overlays/dev/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
   - configmap.yaml
 images:
   - name: daoquocquyen/pong
-    newTag: 1.0.0-b5609f2
+    newTag: 1.0.0-dc475a2
 patches:
   - path: deployment-patch.yaml


### PR DESCRIPTION
Update `kustomization.yaml` to set `newTag: 1.0.0-dc475a2` for `daoquocquyen/pong`.