### PR TITLE
Promote to Prod: ping 1.0.0, pong 1.0.0 (a07b12b)

### DIFF
--- a/ping/overlays/prod/kustomization.yaml
+++ b/ping/overlays/prod/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
 images:
   - name: daoquocquyen/ping
-    newTag: 1.0.0-ba7ee88
+    newTag: 1.0.0-83e47a2
 patches:
   - path: deployment-patch.yaml
   - path: ingress-patch.yaml

--- a/pong/overlays/prod/kustomization.yaml
+++ b/pong/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
   - configmap.yaml
 images:
   - name: daoquocquyen/pong
-    newTag: 1.0.0-340c758
+    newTag: 1.0.0-dae2091
 patches:
   - path: deployment-patch.yaml


### PR DESCRIPTION
Promote to Prod from QA baseline a07b12baa279e5807feaf7124fadb77e30764c85. Release tags: ping=1.0.0, pong=1.0.0.