### PR TITLE
Promote to Prod: ping 1.0.0, pong 1.0.0 (058a07e)

### DIFF
--- a/pong/overlays/prod/kustomization.yaml
+++ b/pong/overlays/prod/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
   - configmap.yaml
 images:
   - name: daoquocquyen/pong
-    newTag: 1.0.0-dae2091
+    newTag: 1.0.0-a30ffaa
 patches:
   - path: deployment-patch.yaml


### PR DESCRIPTION
Promote to Prod from QA baseline 058a07e2b7ffcb876efcb73e02c4c6daf320b4d8. Release tags: ping=1.0.0, pong=1.0.0.