### PR TITLE
chore(pingpong-gitops-config/pong/overlays/dev): bump daoquocquyen/pong to 0.0.2-c9243a6

### DIFF
--- a/pong/overlays/dev/kustomization.yaml
+++ b/pong/overlays/dev/kustomization.yaml
@@ -7,6 +7,6 @@ resources:
   - configmap.yaml
 images:
   - name: daoquocquyen/pong
-    newTag: 0.0.1-abeaed1
+    newTag: 0.0.2-c9243a6
 patches:
   - path: deployment-patch.yaml


### PR DESCRIPTION
Update `kustomization.yaml` to set `newTag: 0.0.2-c9243a6` for `daoquocquyen/pong`.