### PR TITLE
chore(pingpong-gitops-config/ping/overlays/dev): bump daoquocquyen/ping to 0.0.1-28b8966

### DIFF
--- a/ping/overlays/dev/kustomization.yaml
+++ b/ping/overlays/dev/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
   - namespace.yaml
 images:
   - name: daoquocquyen/ping
-    newTag: 0.0.1-883e46a
+    newTag: 0.0.1-28b8966
 patches:
   - path: deployment-patch.yaml
   - path: ingress-patch.yaml


### PR DESCRIPTION
Update `kustomization.yaml` to set `newTag: 0.0.1-28b8966` for `daoquocquyen/ping`.